### PR TITLE
bans feature / dns based wallet address / wallet short names

### DIFF
--- a/VergeiOS.xcodeproj/project.pbxproj
+++ b/VergeiOS.xcodeproj/project.pbxproj
@@ -111,6 +111,7 @@
 		A3764128210A298700E04521 /* AbstractKey.swift in Sources */ = {isa = PBXBuildFile; fileRef = A3764127210A298700E04521 /* AbstractKey.swift */; };
 		A376412C210A500E00E04521 /* PaperKeyDescriptionViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = A376412B210A500E00E04521 /* PaperKeyDescriptionViewController.swift */; };
 		A3764131210AE1D500E04521 /* Platform.swift in Sources */ = {isa = PBXBuildFile; fileRef = A3764130210AE1D500E04521 /* Platform.swift */; };
+		CA50C67F2129CE7F004F5959 /* CloudflareAPIClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA50C67E2129CE7F004F5959 /* CloudflareAPIClient.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -255,6 +256,7 @@
 		A3764127210A298700E04521 /* AbstractKey.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AbstractKey.swift; sourceTree = "<group>"; };
 		A376412B210A500E00E04521 /* PaperKeyDescriptionViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaperKeyDescriptionViewController.swift; sourceTree = "<group>"; };
 		A3764130210AE1D500E04521 /* Platform.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Platform.swift; sourceTree = "<group>"; };
+		CA50C67E2129CE7F004F5959 /* CloudflareAPIClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CloudflareAPIClient.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -655,6 +657,7 @@
 				A37641202108FC1F00E04521 /* TorClient.swift */,
 				07B9F44C2107C6C500871990 /* InsightAPIClient.swift */,
 				A3256662211A39A2006FB08A /* StatisicsAPIClient.swift */,
+				CA50C67E2129CE7F004F5959 /* CloudflareAPIClient.swift */,
 			);
 			path = Http;
 			sourceTree = "<group>";
@@ -959,6 +962,7 @@
 				A305DDA121068BCF00911B64 /* UIFont+Default.swift in Sources */,
 				A338E6BB2110D620000D44EE /* ChartWalletSlideView.swift in Sources */,
 				A302D34D21260F1C00EA8091 /* UIScrollView+Pagination.swift in Sources */,
+				CA50C67F2129CE7F004F5959 /* CloudflareAPIClient.swift in Sources */,
 				A33F6A7020EEE485001492C2 /* AppDelegate.swift in Sources */,
 				A302D2F9211F3F5700EA8091 /* XVGCardImageView.swift in Sources */,
 			);

--- a/VergeiOS/Components/TableCellViews/AddressCell.swift
+++ b/VergeiOS/Components/TableCellViews/AddressCell.swift
@@ -14,4 +14,10 @@ class AddressCell: UITableViewCell {
     @IBAction func pasteButtonClicked(_ sender: Any) {
         addressTextField.text = UIPasteboard.general.string
     }
+    
+    @IBAction func bansInfoButtonClicked(_ sender: Any) {
+        if let url = URL(string: "https://github.com/hellc/bans") {
+            UIApplication.shared.open(url, options: [:])
+        }
+    }
 }

--- a/VergeiOS/Http/CloudflareAPIClient.swift
+++ b/VergeiOS/Http/CloudflareAPIClient.swift
@@ -1,0 +1,43 @@
+//
+//  CloudflareAPIClient.swift
+//  VergeiOS
+//
+//  Created by Ivan Manov on 19/08/2018.
+//  Copyright © 2018 Verge Currency. All rights reserved.
+//
+
+import Foundation
+import SwiftyJSON
+
+class CloudflareAPIClient {
+    
+    static let shared = CloudflareAPIClient()
+    
+    let endpoint: String = "https://dns4torpnlfs2ifuz2s2yf3fc7rdmsbhm6rw75euj35pac6ap25zgqad.onion/dns-query?"
+    
+    func walletAddressFor(currency: String, domainName: String, completion: @escaping (_ address: String?) -> Void) {
+        let url = URL(string: "\(endpoint)name=bans.\(currency).0.\(domainName)&type=TXT")
+        
+        var request = URLRequest(url: url!)
+        request.setValue("application/dns-json", forHTTPHeaderField: "accept")
+        
+        let task = TorClient.shared.session.dataTask(with: request){ (data, resonse, error) in
+            if let data = data {
+                do {
+                    let json = try JSON(data: data)
+                    let result = json["Answer"][0]["data"].string?.replacingOccurrences(of: "\"", with: "")
+                    
+                    completion(result)
+                } catch {
+                    print("Error info: \(error)")
+                    completion(nil)
+                }
+            } else if let _ = error {
+                completion(nil)
+            }
+        }
+        
+        task.resume()
+    }
+}
+

--- a/VergeiOS/Http/CloudflareAPIClient.swift
+++ b/VergeiOS/Http/CloudflareAPIClient.swift
@@ -13,9 +13,12 @@ class CloudflareAPIClient {
     
     static let shared = CloudflareAPIClient()
     
-    let endpoint: String = "https://dns4torpnlfs2ifuz2s2yf3fc7rdmsbhm6rw75euj35pac6ap25zgqad.onion/dns-query?"
+    let torEndpoint: String = "https://dns4torpnlfs2ifuz2s2yf3fc7rdmsbhm6rw75euj35pac6ap25zgqad.onion/dns-query?"
+    let basicEndpoint: String = "https://cloudflare-dns.com/dns-query?"
     
-    func walletAddressFor(currency: String, domainName: String, completion: @escaping (_ address: String?) -> Void) {
+    func walletAddressFor(currency: String, domainName: String, torDns: Bool = true,
+                          completion: @escaping (_ address: String?) -> Void) {
+        let endpoint = torDns ? torEndpoint : basicEndpoint
         let url = URL(string: "\(endpoint)name=bans.\(currency).0.\(domainName)&type=TXT")
         
         var request = URLRequest(url: url!)

--- a/VergeiOS/Storyboards/Send.storyboard
+++ b/VergeiOS/Storyboards/Send.storyboard
@@ -1,13 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="14113" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="aj0-hD-wgD">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="14313.13.2" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="aj0-hD-wgD">
     <device id="retina4_7" orientation="portrait">
         <adaptation id="fullscreen"/>
     </device>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14088"/>
-        <capability name="Aspect ratio constraints" minToolsVersion="5.1"/>
-        <capability name="Constraints to layout margins" minToolsVersion="6.0"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14283.9"/>
         <capability name="Named colors" minToolsVersion="9.0"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="Stack View standard spacing" minToolsVersion="9.0"/>
@@ -163,7 +161,7 @@ Please increase you're balance.</string>
                                                         <rect key="frame" x="0.0" y="64" width="375" height="50"/>
                                                         <subviews>
                                                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Y3r-m1-gqb">
-                                                                <rect key="frame" x="40" y="-0.5" width="295" height="50"/>
+                                                                <rect key="frame" x="40" y="0.0" width="295" height="50"/>
                                                                 <subviews>
                                                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="hYw-Td-wcA" customClass="SelectorButton" customModule="VergeiOS" customModuleProvider="target">
                                                                         <rect key="frame" x="0.0" y="0.0" width="295" height="50"/>
@@ -254,7 +252,7 @@ Please increase you're balance.</string>
                                                 <rect key="frame" x="0.0" y="273" width="375" height="70"/>
                                                 <subviews>
                                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" adjustsImageWhenHighlighted="NO" adjustsImageWhenDisabled="NO" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="1qT-5j-Srg" customClass="RoundedButton" customModule="VergeiOS" customModuleProvider="target">
-                                                        <rect key="frame" x="41" y="0.0" width="294" height="50"/>
+                                                        <rect key="frame" x="40" y="0.0" width="295" height="50"/>
                                                         <color key="backgroundColor" name="PrimaryLight"/>
                                                         <constraints>
                                                             <constraint firstAttribute="width" relation="lessThanOrEqual" constant="300" id="dW1-Nu-dH3"/>
@@ -337,12 +335,12 @@ Please increase you're balance.</string>
                             <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="none" indentationWidth="10" reuseIdentifier="addressCell" id="0qL-Gg-dXJ" customClass="AddressCell" customModule="VergeiOS" customModuleProvider="target">
                                 <rect key="frame" x="0.0" y="55.5" width="375" height="44"/>
                                 <autoresizingMask key="autoresizingMask"/>
-                                <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="0qL-Gg-dXJ" id="VVe-jA-f3z">
+                                <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" ambiguous="YES" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="0qL-Gg-dXJ" id="VVe-jA-f3z">
                                     <rect key="frame" x="0.0" y="0.0" width="375" height="43.5"/>
                                     <autoresizingMask key="autoresizingMask"/>
                                     <subviews>
                                         <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" placeholder="XVG address" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="emq-6W-gA3">
-                                            <rect key="frame" x="16" y="0.0" width="295" height="43.5"/>
+                                            <rect key="frame" x="16" y="0.0" width="295" height="44"/>
                                             <constraints>
                                                 <constraint firstAttribute="height" constant="44" id="g13-0D-6EO"/>
                                             </constraints>
@@ -350,7 +348,7 @@ Please increase you're balance.</string>
                                             <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                             <textInputTraits key="textInputTraits" autocorrectionType="no" spellCheckingType="no" returnKeyType="done" smartDashesType="no" smartInsertDeleteType="no" smartQuotesType="no"/>
                                         </textField>
-                                        <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="x5c-HT-XtI" customClass="RoundedButton" customModule="VergeiOS" customModuleProvider="target">
+                                        <button opaque="NO" contentMode="scaleToFill" ambiguous="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="x5c-HT-XtI" customClass="RoundedButton" customModule="VergeiOS" customModuleProvider="target">
                                             <rect key="frame" x="319" y="7" width="40" height="30"/>
                                             <color key="backgroundColor" name="PrimaryLight"/>
                                             <constraints>
@@ -379,8 +377,53 @@ Please increase you're balance.</string>
                                     <outlet property="addressTextField" destination="emq-6W-gA3" id="jKO-hF-vbC"/>
                                 </connections>
                             </tableViewCell>
-                            <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" reuseIdentifier="useAddressCell" textLabel="Cwr-U5-mFG" style="IBUITableViewCellStyleDefault" id="dzK-wE-Fft">
+                            <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="none" indentationWidth="10" reuseIdentifier="bansAddressCell" id="BA2-bH-YJ8" customClass="AddressCell" customModule="VergeiOS" customModuleProvider="target">
                                 <rect key="frame" x="0.0" y="99.5" width="375" height="44"/>
+                                <autoresizingMask key="autoresizingMask"/>
+                                <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" ambiguous="YES" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="BA2-bH-YJ8" id="9Gw-bR-V2n">
+                                    <rect key="frame" x="0.0" y="0.0" width="375" height="43.5"/>
+                                    <autoresizingMask key="autoresizingMask"/>
+                                    <subviews>
+                                        <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" placeholder="BANS address (ex. wikipedia.org)" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="Q4O-wQ-dhh">
+                                            <rect key="frame" x="16" y="0.0" width="248" height="44"/>
+                                            <constraints>
+                                                <constraint firstAttribute="height" constant="44" id="bcP-wx-mTR"/>
+                                            </constraints>
+                                            <nil key="textColor"/>
+                                            <fontDescription key="fontDescription" type="system" pointSize="14"/>
+                                            <textInputTraits key="textInputTraits" autocorrectionType="no" spellCheckingType="no" returnKeyType="done" smartDashesType="no" smartInsertDeleteType="no" smartQuotesType="no"/>
+                                        </textField>
+                                        <button opaque="NO" contentMode="scaleToFill" ambiguous="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="7dc-Ea-J9s" customClass="RoundedButton" customModule="VergeiOS" customModuleProvider="target">
+                                            <rect key="frame" x="272" y="7" width="87" height="30"/>
+                                            <color key="backgroundColor" name="PrimaryLight"/>
+                                            <constraints>
+                                                <constraint firstAttribute="width" constant="87" id="q9d-L9-rK9"/>
+                                                <constraint firstAttribute="height" constant="30" id="rOt-ag-VWM"/>
+                                            </constraints>
+                                            <fontDescription key="fontDescription" name="AvenirNext-DemiBold" family="Avenir Next" pointSize="11"/>
+                                            <state key="normal" title="  What is BANS?  ">
+                                                <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                            </state>
+                                            <connections>
+                                                <action selector="bansInfoButtonClicked:" destination="BA2-bH-YJ8" eventType="touchUpInside" id="CfF-67-csw"/>
+                                            </connections>
+                                        </button>
+                                    </subviews>
+                                    <constraints>
+                                        <constraint firstAttribute="trailing" secondItem="7dc-Ea-J9s" secondAttribute="trailing" constant="16" id="252-dU-9Wg"/>
+                                        <constraint firstAttribute="bottom" secondItem="Q4O-wQ-dhh" secondAttribute="bottom" id="41e-Zq-Yjj"/>
+                                        <constraint firstItem="Q4O-wQ-dhh" firstAttribute="top" secondItem="9Gw-bR-V2n" secondAttribute="top" id="U8v-hb-ilm"/>
+                                        <constraint firstItem="Q4O-wQ-dhh" firstAttribute="leading" secondItem="9Gw-bR-V2n" secondAttribute="leading" constant="16" id="WfR-PB-mkX"/>
+                                        <constraint firstItem="7dc-Ea-J9s" firstAttribute="centerY" secondItem="9Gw-bR-V2n" secondAttribute="centerY" id="Y4i-a7-xIW"/>
+                                        <constraint firstItem="7dc-Ea-J9s" firstAttribute="leading" secondItem="Q4O-wQ-dhh" secondAttribute="trailing" constant="8" id="gsR-fe-BsY"/>
+                                    </constraints>
+                                </tableViewCellContentView>
+                                <connections>
+                                    <outlet property="addressTextField" destination="Q4O-wQ-dhh" id="ZiB-Cj-KgN"/>
+                                </connections>
+                            </tableViewCell>
+                            <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" reuseIdentifier="useAddressCell" textLabel="Cwr-U5-mFG" style="IBUITableViewCellStyleDefault" id="dzK-wE-Fft">
+                                <rect key="frame" x="0.0" y="143.5" width="375" height="44"/>
                                 <autoresizingMask key="autoresizingMask"/>
                                 <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="dzK-wE-Fft" id="p41-SD-2m1">
                                     <rect key="frame" x="0.0" y="0.0" width="375" height="43.5"/>
@@ -397,7 +440,7 @@ Please increase you're balance.</string>
                                 </tableViewCellContentView>
                             </tableViewCell>
                             <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" reuseIdentifier="addressBookCell" textLabel="6GV-gi-Lfj" detailTextLabel="2oz-Rh-ZHo" style="IBUITableViewCellStyleSubtitle" id="nW3-Cq-3wT">
-                                <rect key="frame" x="0.0" y="143.5" width="375" height="44"/>
+                                <rect key="frame" x="0.0" y="187.5" width="375" height="44"/>
                                 <autoresizingMask key="autoresizingMask"/>
                                 <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="nW3-Cq-3wT" id="nzV-FG-5mB">
                                     <rect key="frame" x="0.0" y="0.0" width="375" height="43.5"/>
@@ -504,7 +547,7 @@ Please increase you're balance.</string>
                                         </connections>
                                     </button>
                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="jgB-Qb-mJf">
-                                        <rect key="frame" x="67" y="214" width="240" height="240"/>
+                                        <rect key="frame" x="67.5" y="213.5" width="240" height="240"/>
                                         <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                         <constraints>
                                             <constraint firstAttribute="height" constant="240" id="ADd-of-7DR"/>
@@ -512,7 +555,7 @@ Please increase you're balance.</string>
                                         </constraints>
                                     </view>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Scan a XVG QR code" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="0WT-oX-zie">
-                                        <rect key="frame" x="106" y="160" width="162" height="24"/>
+                                        <rect key="frame" x="106.5" y="159.5" width="162" height="24"/>
                                         <fontDescription key="fontDescription" name="AvenirNext-Regular" family="Avenir Next" pointSize="17"/>
                                         <color key="textColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                         <nil key="highlightedColor"/>
@@ -666,19 +709,10 @@ Please increase you're balance.</string>
         <image name="SendCard" width="735" height="475"/>
         <image name="TouchID" width="30" height="30"/>
         <namedColor name="BackgroundGrey">
-            <color red="0.97299999000000004" green="0.96899998190000003" blue="0.96899998190000003" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-        </namedColor>
-        <namedColor name="BackgroundGrey">
-            <color red="0.97299998998641968" green="0.96899998188018799" blue="0.96899998188018799" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-        </namedColor>
-        <namedColor name="BackgroundGrey">
             <color red="0.97299998998641968" green="0.96899998188018799" blue="0.96899998188018799" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
         </namedColor>
         <namedColor name="PrimaryLight">
             <color red="0.21600000560283661" green="0.74099999666213989" blue="0.88599997758865356" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-        </namedColor>
-        <namedColor name="SecondaryDark">
-            <color red="0.097999997437000275" green="0.23899999260902405" blue="0.33300000429153442" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
         </namedColor>
         <namedColor name="SecondaryDark">
             <color red="0.097999997437000275" green="0.23899999260902405" blue="0.33300000429153442" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>

--- a/VergeiOS/Views/Send/ScanQRCodeViewController.swift
+++ b/VergeiOS/Views/Send/ScanQRCodeViewController.swift
@@ -119,7 +119,7 @@ class ScanQRCodeViewController: UIViewController, AVCaptureMetadataOutputObjects
     
 
     // MARK: - Navigation
-
+    
     @IBAction func closeController(_ sender: Any) {
         self.dismiss(animated: true) {
             self.captureSession?.stopRunning()


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
We could easily provide short names in XVG wallets using secured DNS.
Here is some description of my DNS method: https://github.com/hellc/bans
Here is the short demo video: https://youtu.be/A94jY8ZhCbA

## Motivation and Context
I don't like [this](https://www.coindesk.com/ethereum-is-getting-its-first-top-level-domain-name/) sloppy method. I think we could do it more easily and accessibly.