### PR TITLE
Additional fiat currencies

### DIFF
--- a/VergeiOS/Views/Settings/CurrencyTableViewController.swift
+++ b/VergeiOS/Views/Settings/CurrencyTableViewController.swift
@@ -36,6 +36,10 @@ class CurrencyTableViewController: EdgedTableViewController {
             "name": "Chinese Yuan",
         ],
         [
+            "currency": "DKK",
+            "name": "Danish krone",
+        ],
+        [
             "currency": "EUR",
             "name": "Euro",
         ],
@@ -50,6 +54,18 @@ class CurrencyTableViewController: EdgedTableViewController {
         [
             "currency": "IDR",
             "name": "Indonesian Rupiah",
+        ],
+        [
+            "currency": "RUB",
+            "name": "Russian Ruble",
+        ],
+        [
+            "currency": "SGD",
+            "name": "Singapore dollar",
+        ],
+        [
+            "currency": "THB",
+            "name": "Thai Baht",
         ],
         [
             "currency": "USD",


### PR DESCRIPTION
Additional fiat currencies (RUB, DKK, SGD, THB)

Update endpoint to support following currencies
`https://usxvglw.vergecoreteam.com/price/api/v1/price/RUB` or etc

## Related Issue
https://github.com/vergecurrency/vIOS/issues/69

## Motivation and Context
We need more currencies support for international stores usage
I need Russian Ruble for myself

## Screenshots:

<img src="https://user-images.githubusercontent.com/750178/50843036-02c5d180-1379-11e9-8332-fd21e9fe1b0c.JPG" width="375" height="667">

## Types of changes
- [x] Update endpoint _/price/api/v1/price/_ to support related currencies
- [x] Test / Deploy

