### PR TITLE
Siri shortcuts integration

### DIFF
--- a/VergeSiri/Info.plist
+++ b/VergeSiri/Info.plist
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleDisplayName</key>
+	<string>VergeSiri</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>XPC!</string>
+	<key>CFBundleShortVersionString</key>
+	<string>0.14</string>
+	<key>CFBundleVersion</key>
+	<string>0.14</string>
+	<key>NSExtension</key>
+	<dict>
+		<key>NSExtensionAttributes</key>
+		<dict>
+			<key>IntentsRestrictedWhileLocked</key>
+			<array/>
+			<key>IntentsRestrictedWhileProtectedDataUnavailable</key>
+			<array/>
+			<key>IntentsSupported</key>
+			<array>
+				<string>VergePriceIntent</string>
+			</array>
+		</dict>
+		<key>NSExtensionPointIdentifier</key>
+		<string>com.apple.intents-service</string>
+		<key>NSExtensionPrincipalClass</key>
+		<string>$(PRODUCT_MODULE_NAME).IntentHandler</string>
+	</dict>
+</dict>
+</plist>

--- a/VergeSiri/IntentHandler.swift
+++ b/VergeSiri/IntentHandler.swift
@@ -1,0 +1,56 @@
+//
+//  IntentHandler.swift
+//  VergeSiri
+//
+//  Created by Ivan Manov on 1/10/19.
+//  Copyright © 2019 Verge Currency. All rights reserved.
+//
+
+import Intents
+
+@available(iOSApplicationExtension 12.0, *)
+class IntentHandler: INExtension {
+    override func handler(for intent: INIntent) -> Any {
+        guard intent is VergePriceIntent else {
+            fatalError("Unhandled intent type: \(intent)")
+        }
+        
+        return PriceIntentHandler()
+    }
+}
+
+@available(iOSApplicationExtension 12.0, *)
+class PriceIntentHandler: NSObject, VergePriceIntentHandling {
+    
+    func handle(intent: VergePriceIntent, completion: @escaping (VergePriceIntentResponse) -> Void) {
+        
+        getPriceForCurrency(currency: "USD") { (priceResult) in
+            if (priceResult != nil && priceResult!.doubleValue >= 0) {
+                let result = String(format: "%.4f $", priceResult!.doubleValue)
+                completion(VergePriceIntentResponse.success(price: result))
+            } else {
+                completion(VergePriceIntentResponse.init(code: .failure, userActivity: nil))
+            }
+        }
+    }
+    
+    func getPriceForCurrency(currency: String, completion: @escaping (_ result: NSDecimalNumber?) -> Void) {
+        let url = URL(string: "\(Config.priceDataEndpoint)\(currency)")
+        
+        let task = URLSession.shared.dataTask(with: url!) {(data, response, error) in
+            if let data = data {
+                do {
+                    let statistics = try JSONDecoder().decode(Statistics.self, from: data)
+                    completion(NSDecimalNumber(value: statistics.price))
+                } catch {
+                    print("Error info: \(error)")
+                    completion(nil)
+                }
+            } else if let _ = error {
+                completion(nil)
+            }
+        }
+        
+        task.resume()
+    }
+}

--- a/VergeiOS.xcodeproj/project.pbxproj
+++ b/VergeiOS.xcodeproj/project.pbxproj
@@ -1738,7 +1738,7 @@
 				CODE_SIGN_ENTITLEMENTS = VergeiOS/VergeiOS.entitlements;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 0.1;
-				DEVELOPMENT_TEAM = "";
+				DEVELOPMENT_TEAM = S7743EWR3C;
 				DYLIB_CURRENT_VERSION = 0.1;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
@@ -1766,7 +1766,7 @@
 				CODE_SIGN_ENTITLEMENTS = VergeiOS/VergeiOS.entitlements;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 0.1;
-				DEVELOPMENT_TEAM = "";
+				DEVELOPMENT_TEAM = S7743EWR3C;
 				DYLIB_CURRENT_VERSION = 0.1;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
@@ -1790,7 +1790,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CODE_SIGN_STYLE = Automatic;
-				DEVELOPMENT_TEAM = "";
+				DEVELOPMENT_TEAM = S7743EWR3C;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(PROJECT_DIR)/Carthage/Build/iOS",
@@ -1816,7 +1816,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CODE_SIGN_STYLE = Automatic;
-				DEVELOPMENT_TEAM = "";
+				DEVELOPMENT_TEAM = S7743EWR3C;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(PROJECT_DIR)/Carthage/Build/iOS",

--- a/VergeiOS.xcodeproj/project.pbxproj
+++ b/VergeiOS.xcodeproj/project.pbxproj
@@ -197,6 +197,12 @@
 		B2BD7F39EE96EB7B9E5A870A /* SendTransaction.swift in Sources */ = {isa = PBXBuildFile; fileRef = B2BD780B0BE45F52AD3B526D /* SendTransaction.swift */; };
 		B2BD7F7547EA2B385CD74E57 /* Collection+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = B2BD74E5640073CDD7246E24 /* Collection+Extensions.swift */; };
 		B2BD7FCE5B75C5C1D6DE3F70 /* SJCL.swift in Sources */ = {isa = PBXBuildFile; fileRef = B2BD7B2AFFB4647DEE6C6A8E /* SJCL.swift */; };
+		CAD929F521E7DFA300CD5EBA /* IntentHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = CAD929F421E7DFA300CD5EBA /* IntentHandler.swift */; };
+		CAD929F921E7DFA300CD5EBA /* VergeSiri.appex in Embed App Extensions */ = {isa = PBXBuildFile; fileRef = CAD929F221E7DFA200CD5EBA /* VergeSiri.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
+		CAD92A0021E7E07100CD5EBA /* Intents.intentdefinition in Sources */ = {isa = PBXBuildFile; fileRef = CAD929FF21E7E07100CD5EBA /* Intents.intentdefinition */; };
+		CAD92A0121E7E12900CD5EBA /* Intents.intentdefinition in Sources */ = {isa = PBXBuildFile; fileRef = CAD929FF21E7E07100CD5EBA /* Intents.intentdefinition */; };
+		CAD92A0721E7EC3B00CD5EBA /* Config.swift in Sources */ = {isa = PBXBuildFile; fileRef = A3E8FF32217B7ED700CB50ED /* Config.swift */; };
+		CAD92A0821E7ECE300CD5EBA /* Statistics.swift in Sources */ = {isa = PBXBuildFile; fileRef = A3256664211A3B61006FB08A /* Statistics.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -214,6 +220,13 @@
 			remoteGlobalIDString = A33F6A6B20EEE485001492C2;
 			remoteInfo = VergeiOS;
 		};
+		CAD929F721E7DFA300CD5EBA /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = A33F6A6420EEE485001492C2 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = CAD929F121E7DFA200CD5EBA;
+			remoteInfo = VergeSiri;
+		};
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXCopyFilesBuildPhase section */
@@ -225,6 +238,17 @@
 			files = (
 			);
 			name = "Embed Frameworks";
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		CAD929FD21E7DFA300CD5EBA /* Embed App Extensions */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = "";
+			dstSubfolderSpec = 13;
+			files = (
+				CAD929F921E7DFA300CD5EBA /* VergeSiri.appex in Embed App Extensions */,
+			);
+			name = "Embed App Extensions";
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXCopyFilesBuildPhase section */
@@ -430,6 +454,10 @@
 		B2BD7EF009F29B5AAA801A96 /* NotificationManager.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NotificationManager.swift; sourceTree = "<group>"; };
 		B2BD7F498F12AE2C1C892E66 /* AppDelegate+NotificationCenter.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "AppDelegate+NotificationCenter.swift"; sourceTree = "<group>"; };
 		B2BD7FCD299CE8410048C780 /* NotificationViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NotificationViewController.swift; sourceTree = "<group>"; };
+		CAD929F221E7DFA200CD5EBA /* VergeSiri.appex */ = {isa = PBXFileReference; explicitFileType = "wrapper.app-extension"; includeInIndex = 0; path = VergeSiri.appex; sourceTree = BUILT_PRODUCTS_DIR; };
+		CAD929F421E7DFA300CD5EBA /* IntentHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IntentHandler.swift; sourceTree = "<group>"; };
+		CAD929F621E7DFA300CD5EBA /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		CAD929FF21E7E07100CD5EBA /* Intents.intentdefinition */ = {isa = PBXFileReference; lastKnownFileType = file.intentdefinition; path = Intents.intentdefinition; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -463,6 +491,13 @@
 				A3647286217CF9A9001B1B18 /* Eureka.framework in Frameworks */,
 				A3408E56217687F9009F0C9D /* Charts.framework in Frameworks */,
 				A325666A211B9ABC006FB08A /* KeychainSwift.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		CAD929EF21E7DFA200CD5EBA /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -564,6 +599,7 @@
 		A305DD9A21066AE600911B64 /* Components */ = {
 			isa = PBXGroup;
 			children = (
+				CAD929FE21E7E05900CD5EBA /* Siri */,
 				B2BD7DE012024B6499CAA5BE /* WalletChart */,
 				B2BD7713B76A4A8371FACC27 /* Notification */,
 				A3AA21FA2163F64F00160576 /* TorStatusIndicator */,
@@ -824,6 +860,7 @@
 				A33F6A6E20EEE485001492C2 /* VergeiOS */,
 				A3256679211CBA9A006FB08A /* VergeiOSTests */,
 				A3256695211CBBE2006FB08A /* VergeiOSUITests */,
+				CAD929F321E7DFA300CD5EBA /* VergeSiri */,
 				A33F6A6D20EEE485001492C2 /* Products */,
 				A37641112108E79800E04521 /* Frameworks */,
 			);
@@ -835,6 +872,7 @@
 				A33F6A6C20EEE485001492C2 /* VergeiOS.app */,
 				A3256678211CBA9A006FB08A /* VergeiOSTests.xctest */,
 				A3256694211CBBE2006FB08A /* VergeiOSUITests.xctest */,
+				CAD929F221E7DFA200CD5EBA /* VergeSiri.appex */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -995,6 +1033,23 @@
 			path = WalletChart;
 			sourceTree = "<group>";
 		};
+		CAD929F321E7DFA300CD5EBA /* VergeSiri */ = {
+			isa = PBXGroup;
+			children = (
+				CAD929F421E7DFA300CD5EBA /* IntentHandler.swift */,
+				CAD929F621E7DFA300CD5EBA /* Info.plist */,
+			);
+			path = VergeSiri;
+			sourceTree = "<group>";
+		};
+		CAD929FE21E7E05900CD5EBA /* Siri */ = {
+			isa = PBXGroup;
+			children = (
+				CAD929FF21E7E07100CD5EBA /* Intents.intentdefinition */,
+			);
+			path = Siri;
+			sourceTree = "<group>";
+		};
 /* End PBXGroup section */
 
 /* Begin PBXNativeTarget section */
@@ -1044,15 +1099,34 @@
 				A376411E2108F7D200E04521 /* Run Script */,
 				A3C5C3C42196EFB6003B6C02 /* Embed Frameworks */,
 				A35F3D80211CDA2D006068A2 /* ShellScript */,
+				CAD929FD21E7DFA300CD5EBA /* Embed App Extensions */,
 			);
 			buildRules = (
 			);
 			dependencies = (
+				CAD929F821E7DFA300CD5EBA /* PBXTargetDependency */,
 			);
 			name = VergeiOS;
 			productName = VergeCurrencyWallet;
 			productReference = A33F6A6C20EEE485001492C2 /* VergeiOS.app */;
 			productType = "com.apple.product-type.application";
+		};
+		CAD929F121E7DFA200CD5EBA /* VergeSiri */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = CAD929FA21E7DFA300CD5EBA /* Build configuration list for PBXNativeTarget "VergeSiri" */;
+			buildPhases = (
+				CAD929EE21E7DFA200CD5EBA /* Sources */,
+				CAD929EF21E7DFA200CD5EBA /* Frameworks */,
+				CAD929F021E7DFA200CD5EBA /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = VergeSiri;
+			productName = VergeSiri;
+			productReference = CAD929F221E7DFA200CD5EBA /* VergeSiri.appex */;
+			productType = "com.apple.product-type.app-extension";
 		};
 /* End PBXNativeTarget section */
 
@@ -1063,7 +1137,7 @@
 				KnownAssetTags = (
 					rateapp,
 				);
-				LastSwiftUpdateCheck = 0940;
+				LastSwiftUpdateCheck = 1010;
 				LastUpgradeCheck = 0940;
 				ORGANIZATIONNAME = "Verge Currency";
 				TargetAttributes = {
@@ -1096,7 +1170,13 @@
 							com.apple.Push = {
 								enabled = 1;
 							};
+							com.apple.Siri = {
+								enabled = 1;
+							};
 						};
+					};
+					CAD929F121E7DFA200CD5EBA = {
+						CreatedOnToolsVersion = 10.1;
 					};
 				};
 			};
@@ -1116,6 +1196,7 @@
 				A33F6A6B20EEE485001492C2 /* VergeiOS */,
 				A3256677211CBA9A006FB08A /* VergeiOSTests */,
 				A3256693211CBBE2006FB08A /* VergeiOSUITests */,
+				CAD929F121E7DFA200CD5EBA /* VergeSiri */,
 			);
 		};
 /* End PBXProject section */
@@ -1168,6 +1249,13 @@
 				A338E6BD2110D642000D44EE /* SummaryWalletSlideView.xib in Resources */,
 				A32566452113729C006FB08A /* Receive.storyboard in Resources */,
 				A386CA9B219E28FA00FBF465 /* SendingView.xib in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		CAD929F021E7DFA200CD5EBA /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1306,6 +1394,7 @@
 				A3D68365213F34E50067E0B9 /* TransactionTableViewCell.swift in Sources */,
 				A338E69C210D456D000D44EE /* ConfirmPaperkeyViewController.swift in Sources */,
 				A398B21B212F91F0004ACB73 /* ConfirmSendView.swift in Sources */,
+				CAD92A0021E7E07100CD5EBA /* Intents.intentdefinition in Sources */,
 				A325664D211375E5006FB08A /* PinUnlockViewController.swift in Sources */,
 				A38D6F8221C17EFB00280FFE /* AddressesTableViewController.swift in Sources */,
 				A3408E5821768AF4009F0C9D /* Date+Extensions.swift in Sources */,
@@ -1396,6 +1485,17 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		CAD929EE21E7DFA200CD5EBA /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				CAD92A0121E7E12900CD5EBA /* Intents.intentdefinition in Sources */,
+				CAD929F521E7DFA300CD5EBA /* IntentHandler.swift in Sources */,
+				CAD92A0821E7ECE300CD5EBA /* Statistics.swift in Sources */,
+				CAD92A0721E7EC3B00CD5EBA /* Config.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXSourcesBuildPhase section */
 
 /* Begin PBXTargetDependency section */
@@ -1408,6 +1508,11 @@
 			isa = PBXTargetDependency;
 			target = A33F6A6B20EEE485001492C2 /* VergeiOS */;
 			targetProxy = A325669C211CBBE5006FB08A /* PBXContainerItemProxy */;
+		};
+		CAD929F821E7DFA300CD5EBA /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = CAD929F121E7DFA200CD5EBA /* VergeSiri */;
+			targetProxy = CAD929F721E7DFA300CD5EBA /* PBXContainerItemProxy */;
 		};
 /* End PBXTargetDependency section */
 
@@ -1628,11 +1733,12 @@
 		A33F6A9820EEE487001492C2 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_ENTITLEMENTS = VergeiOS/VergeiOS.entitlements;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 0.1;
-				DEVELOPMENT_TEAM = S7743EWR3C;
+				DEVELOPMENT_TEAM = "";
 				DYLIB_CURRENT_VERSION = 0.1;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
@@ -1655,11 +1761,12 @@
 		A33F6A9920EEE487001492C2 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_ENTITLEMENTS = VergeiOS/VergeiOS.entitlements;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 0.1;
-				DEVELOPMENT_TEAM = S7743EWR3C;
+				DEVELOPMENT_TEAM = "";
 				DYLIB_CURRENT_VERSION = 0.1;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
@@ -1676,6 +1783,57 @@
 				SWIFT_VERSION = 4.2;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				VERSIONING_SYSTEM = "apple-generic";
+			};
+			name = Release;
+		};
+		CAD929FB21E7DFA300CD5EBA /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_STYLE = Automatic;
+				DEVELOPMENT_TEAM = "";
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PROJECT_DIR)/Carthage/Build/iOS",
+				);
+				INFOPLIST_FILE = VergeSiri/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 11.4;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@executable_path/../../Frameworks",
+				);
+				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
+				MTL_FAST_MATH = YES;
+				PRODUCT_BUNDLE_IDENTIFIER = org.verge.ioswallet.VergeSiri;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SKIP_INSTALL = YES;
+				SWIFT_VERSION = 4.2;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Debug;
+		};
+		CAD929FC21E7DFA300CD5EBA /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_STYLE = Automatic;
+				DEVELOPMENT_TEAM = "";
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PROJECT_DIR)/Carthage/Build/iOS",
+				);
+				INFOPLIST_FILE = VergeSiri/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 11.4;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@executable_path/../../Frameworks",
+				);
+				MTL_FAST_MATH = YES;
+				PRODUCT_BUNDLE_IDENTIFIER = org.verge.ioswallet.VergeSiri;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SKIP_INSTALL = YES;
+				SWIFT_VERSION = 4.2;
+				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Release;
 		};
@@ -1714,6 +1872,15 @@
 			buildConfigurations = (
 				A33F6A9820EEE487001492C2 /* Debug */,
 				A33F6A9920EEE487001492C2 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		CAD929FA21E7DFA300CD5EBA /* Build configuration list for PBXNativeTarget "VergeSiri" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				CAD929FB21E7DFA300CD5EBA /* Debug */,
+				CAD929FC21E7DFA300CD5EBA /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;

--- a/VergeiOS/AppDelegate.swift
+++ b/VergeiOS/AppDelegate.swift
@@ -7,6 +7,7 @@
 //
 
 import UIKit
+import Intents
 import CoreData
 import CoreStore
 import IQKeyboardManagerSwift
@@ -109,6 +110,10 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
         // Start the wallet ticker.
         WalletTicker.shared.start()
+        
+        if #available(iOS 12.0, *) {
+            self.donateSiriIntents()
+        }
     }
     
     func registerAppforDetectLockState() {
@@ -152,4 +157,21 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         }
     }
     
+    @available(iOS 12.0, *)
+    func donateSiriIntents() {
+        let priceIntent = VergePriceIntent()
+        priceIntent.suggestedInvocationPhrase = "Verge price"
+        
+        let interaction = INInteraction(intent: priceIntent, response: nil)
+        
+        interaction.donate { (error) in
+            if error != nil {
+                if let error = error as NSError? {
+                    NSLog("Interaction donation failed: %@", error)
+                } else {
+                    NSLog("Successfully donated interaction")
+                }
+            }
+        }
+    }
 }

--- a/VergeiOS/Components/Siri/Intents.intentdefinition
+++ b/VergeiOS/Components/Siri/Intents.intentdefinition
@@ -1,0 +1,106 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>INEnums</key>
+	<array/>
+	<key>INIntentDefinitionModelVersion</key>
+	<string>1.0</string>
+	<key>INIntentDefinitionSystemVersion</key>
+	<string>18C54</string>
+	<key>INIntentDefinitionToolsBuildVersion</key>
+	<string>10B61</string>
+	<key>INIntentDefinitionToolsVersion</key>
+	<string>10.1</string>
+	<key>INIntents</key>
+	<array>
+		<dict>
+			<key>INIntentCategory</key>
+			<string>download</string>
+			<key>INIntentDescription</key>
+			<string>Ask Siri about Verge Price</string>
+			<key>INIntentDescriptionID</key>
+			<string>yuY2j3</string>
+			<key>INIntentLastParameterTag</key>
+			<integer>0</integer>
+			<key>INIntentName</key>
+			<string>VergePrice</string>
+			<key>INIntentParameterCombinations</key>
+			<dict>
+				<key></key>
+				<dict>
+					<key>INIntentParameterCombinationIsPrimary</key>
+					<true/>
+					<key>INIntentParameterCombinationSubtitle</key>
+					<string></string>
+					<key>INIntentParameterCombinationSubtitleID</key>
+					<string>u43rt7</string>
+					<key>INIntentParameterCombinationSupportsBackgroundExecution</key>
+					<true/>
+					<key>INIntentParameterCombinationTitle</key>
+					<string>Verge Price</string>
+					<key>INIntentParameterCombinationTitleID</key>
+					<string>oDtdRL</string>
+				</dict>
+			</dict>
+			<key>INIntentParameters</key>
+			<array/>
+			<key>INIntentResponse</key>
+			<dict>
+				<key>INIntentResponseCodes</key>
+				<array>
+					<dict>
+						<key>INIntentResponseCodeFormatString</key>
+						<string>Sorry, can't get the price right now</string>
+						<key>INIntentResponseCodeFormatStringID</key>
+						<string>EK5hmf</string>
+						<key>INIntentResponseCodeName</key>
+						<string>failure</string>
+						<key>INIntentResponseCodeSuccess</key>
+						<false/>
+					</dict>
+					<dict>
+						<key>INIntentResponseCodeFormatString</key>
+						<string>Current Verge price is ${price}</string>
+						<key>INIntentResponseCodeFormatStringID</key>
+						<string>JXIeje</string>
+						<key>INIntentResponseCodeName</key>
+						<string>success</string>
+						<key>INIntentResponseCodeSuccess</key>
+						<true/>
+					</dict>
+				</array>
+				<key>INIntentResponseLastParameterTag</key>
+				<integer>8</integer>
+				<key>INIntentResponseParameters</key>
+				<array>
+					<dict>
+						<key>INIntentResponseParameterDisplayPriority</key>
+						<integer>1</integer>
+						<key>INIntentResponseParameterName</key>
+						<string>price</string>
+						<key>INIntentResponseParameterSupportsMultipleValues</key>
+						<false/>
+						<key>INIntentResponseParameterTag</key>
+						<integer>7</integer>
+						<key>INIntentResponseParameterType</key>
+						<string>String</string>
+					</dict>
+				</array>
+			</dict>
+			<key>INIntentRestrictions</key>
+			<integer>0</integer>
+			<key>INIntentTitle</key>
+			<string>Verge Price</string>
+			<key>INIntentTitleID</key>
+			<string>iSD29I</string>
+			<key>INIntentType</key>
+			<string>Custom</string>
+			<key>INIntentUserConfirmationRequired</key>
+			<false/>
+			<key>INIntentVerb</key>
+			<string>Get</string>
+		</dict>
+	</array>
+</dict>
+</plist>

--- a/VergeiOS/Info.plist
+++ b/VergeiOS/Info.plist
@@ -56,6 +56,10 @@
 	<string>This app uses Face ID to unlock it</string>
 	<key>NSPhotoLibraryAddUsageDescription</key>
 	<string>This app uses the photo library to save QR codes</string>
+	<key>NSUserActivityTypes</key>
+	<array>
+		<string>VergePriceIntent</string>
+	</array>
 	<key>UIBackgroundModes</key>
 	<array>
 		<string>remote-notification</string>

--- a/VergeiOS/VergeiOS.entitlements
+++ b/VergeiOS/VergeiOS.entitlements
@@ -4,5 +4,7 @@
 <dict>
 	<key>aps-environment</key>
 	<string>development</string>
+	<key>com.apple.developer.siri</key>
+	<true/>
 </dict>
 </plist>


### PR DESCRIPTION
## Description

Allow to use app related requests thought Siri
(Verge price as an example)

## Demo:
iOS Demo: https://youtu.be/yGDpWHP7aZU
HomePod demo: https://www.youtube.com/watch?v=X2l6GgCOnQU


## Motivation and Context
* Ability to use Apple iOS Shortcuts related with Verge App by interaction with Siri on HomePod (yeah, even HomePod...) and iOS devices.
* This pull is base code for shortcuts / Siri commands. We could add more commands then. Right now its just one ("Hey Siri, Verge Price")
* Siri don't know about Verge...no price info and etc.

## How to test
Due the developing:
1. Enable Siri in system settings (if did not)
2. Go to Setting -> Developer -> Turn on shortcuts testing (scr.)

<img src="https://user-images.githubusercontent.com/750178/51002053-22a8f100-1543-11e9-9a93-c38ebf907512.png" width="187" height="333">

3. Build an app and Run it (need to donate intents in app delegate). Don't forget to include developer info for VergeSiri target
4. Go to shortcuts and include Verge app related

<img src="https://user-images.githubusercontent.com/750178/51002241-b24e9f80-1543-11e9-8f4c-f70f932eb925.png" width="187" height="333"><img src="https://user-images.githubusercontent.com/750178/51002273-d5794f00-1543-11e9-9d98-124a1125a7ed.png" width="187" height="333">

Have fun =)