### PR TITLE
Efficient address generation and error handling

### DIFF
--- a/VergeiOS.xcodeproj/project.pbxproj
+++ b/VergeiOS.xcodeproj/project.pbxproj
@@ -162,6 +162,7 @@
 		B2BD717BC2C013EDDB11EB48 /* NotificationViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B2BD7FCD299CE8410048C780 /* NotificationViewController.swift */; };
 		B2BD71BB2B06C6F10205ECBC /* ChartFilterToolbarDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = B2BD7BE7344909C100B67E17 /* ChartFilterToolbarDelegate.swift */; };
 		B2BD7216E5E949A43C2B4FC4 /* TxOutput.swift in Sources */ = {isa = PBXBuildFile; fileRef = B2BD733F9D032CB620B66904 /* TxOutput.swift */; };
+		B2BD724949D1989F82E187A8 /* CreateAddressErrorResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = B2BD7FE6CE69F7288EADDB6F /* CreateAddressErrorResponse.swift */; };
 		B2BD72F8A7F67D4C11416F74 /* RecipientDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = B2BD74068BD3DBE015E9B35E /* RecipientDelegate.swift */; };
 		B2BD734546C80289A73FBA46 /* WalletClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = B2BD78A6683D5C34785959E3 /* WalletClient.swift */; };
 		B2BD736A7A645161F7FF846D /* PaperkeyViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B2BD7BF3055148691DE401AD /* PaperkeyViewController.swift */; };
@@ -453,6 +454,7 @@
 		B2BD7EF009F29B5AAA801A96 /* NotificationManager.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NotificationManager.swift; sourceTree = "<group>"; };
 		B2BD7F498F12AE2C1C892E66 /* AppDelegate+NotificationCenter.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "AppDelegate+NotificationCenter.swift"; sourceTree = "<group>"; };
 		B2BD7FCD299CE8410048C780 /* NotificationViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NotificationViewController.swift; sourceTree = "<group>"; };
+		B2BD7FE6CE69F7288EADDB6F /* CreateAddressErrorResponse.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CreateAddressErrorResponse.swift; sourceTree = "<group>"; };
 		CAD929F221E7DFA200CD5EBA /* VergeSiri.appex */ = {isa = PBXFileReference; explicitFileType = "wrapper.app-extension"; includeInIndex = 0; path = VergeSiri.appex; sourceTree = BUILT_PRODUCTS_DIR; };
 		CAD929F421E7DFA300CD5EBA /* IntentHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IntentHandler.swift; sourceTree = "<group>"; };
 		CAD929F621E7DFA300CD5EBA /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
@@ -1015,6 +1017,7 @@
 				B2BD733F9D032CB620B66904 /* TxOutput.swift */,
 				B2BD73930AE34F70DFA6F652 /* TxChangeAddress.swift */,
 				B2BD74B4143A368E99C1180D /* TxProposalErrorResponse.swift */,
+				B2BD7FE6CE69F7288EADDB6F /* CreateAddressErrorResponse.swift */,
 			);
 			path = Models;
 			sourceTree = "<group>";
@@ -1479,6 +1482,7 @@
 				B2BD7851B858E027F5497F2B /* TransactionManager.swift in Sources */,
 				B2BD73C50F4BA27C71F772FB /* Data+Extensions.swift in Sources */,
 				B2BD77F17789C2C495FDA9A9 /* TxProposalErrorResponse.swift in Sources */,
+				B2BD724949D1989F82E187A8 /* CreateAddressErrorResponse.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/VergeiOS/Extensions/UIAlertController+Statics.swift
+++ b/VergeiOS/Extensions/UIAlertController+Statics.swift
@@ -47,4 +47,17 @@ extension UIAlertController {
 
         return alert
     }
+
+    static func createAddressGapReachedAlert() -> UIAlertController {
+        let alert = UIAlertController(
+            title: "Cannot create address",
+            message: "The maximum of inactive addresses have been reached. " +
+                "Use one of the already generated addresses to create a new one.",
+            preferredStyle: .alert
+        )
+
+        alert.addAction(UIAlertAction(title: "Ok", style: .cancel))
+
+        return alert
+    }
 }

--- a/VergeiOS/Kernel/Wallet/Models/CreateAddressErrorResponse.swift
+++ b/VergeiOS/Kernel/Wallet/Models/CreateAddressErrorResponse.swift
@@ -1,0 +1,25 @@
+//
+// Created by Swen van Zanten on 2019-01-21.
+// Copyright (c) 2019 Verge Currency. All rights reserved.
+//
+
+import Foundation
+
+public struct CreateAddressErrorResponse: Decodable {
+
+    public enum Error: String {
+        case MainAddressGapReached = "MAIN_ADDRESS_GAP_REACHED"
+    }
+
+    public let code: String
+    public let message: String
+
+}
+
+public extension CreateAddressErrorResponse {
+
+    public var error: CreateAddressErrorResponse.Error? {
+        return CreateAddressErrorResponse.Error.init(rawValue: code)
+    }
+
+}

--- a/VergeiOS/Kernel/Wallet/WalletClient.swift
+++ b/VergeiOS/Kernel/Wallet/WalletClient.swift
@@ -182,16 +182,19 @@ public class WalletClient {
         }
     }
 
-    public func createAddress(completion: @escaping (_ error: Error?, _ address: AddressInfo?) -> Void) {
+    public func createAddress(
+        completion: @escaping (_ error: Error?, _ address: AddressInfo?, _ createAddressErrorResponse: CreateAddressErrorResponse?) -> Void
+    ) {
         postRequest(url: "/v3/addresses/", arguments: nil) { data, response, error in
             if let data = data {
                 do {
                     let addressInfo = try JSONDecoder().decode(AddressInfo.self, from: data)
-                    completion(error, addressInfo)
+                    completion(error, addressInfo, nil)
                 } catch {
-                    print(error)
-                    completion(error, nil)
+                    completion(error, nil, try? JSONDecoder().decode(CreateAddressErrorResponse.self, from: data))
                 }
+            } else {
+                completion(error, nil, nil)
             }
         }
     }

--- a/VergeiOS/Views/Settings/AddressesTableViewController.swift
+++ b/VergeiOS/Views/Settings/AddressesTableViewController.swift
@@ -16,12 +16,15 @@ class AddressesTableViewController: EdgedTableViewController {
         super.viewDidLoad()
 
         var options = WalletAddressesOptions()
-        options.limit = 15
+        options.limit = 25
         options.reverse = true
 
         WalletClient.shared.getMainAddresses(options: options) { addresses in
+            self.addresses = addresses.filter { addressInfo in
+                return TransactionManager.shared.all(byAddress: addressInfo.address).count == 0
+            }
+
             DispatchQueue.main.async {
-                self.addresses = addresses
                 self.tableView.reloadData()
             }
         }
@@ -42,7 +45,7 @@ class AddressesTableViewController: EdgedTableViewController {
     }
 
     override func tableView(_ tableView: UITableView, titleForHeaderInSection section: Int) -> String? {
-        return "Last \(addresses.count) unused addresses"
+        return "Unused addresses"
     }
 
     override func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {


### PR DESCRIPTION
#89 

- An address will only be created when the last address received funds.
- When manually refreshing the address generator it will give an error when the maximum gap is reached and show the last unused one.
- The settings > addresses view only shows the addresses that are unused.
